### PR TITLE
Update cloudOfDaggers.js

### DIFF
--- a/scripts/macros/cloudOfDaggers.js
+++ b/scripts/macros/cloudOfDaggers.js
@@ -45,7 +45,7 @@ export async function cloudOfDaggers({tokenUuid, regionUuid, regionScenario, reg
 
     let castLevel = template.getFlag("gambits-premades", "codCastLevel");
 
-    let damageDice =  castLevel + 2;
+    let damageDice =  (2*(castLevel - 2)) + 4;
     let damageRoll = await new CONFIG.Dice.DamageRoll(`${damageDice}d4`).evaluate();
     await MidiQOL.displayDSNForRoll(damageRoll, 'damageRoll');
 


### PR DESCRIPTION
Updated the damage dice per level of CoD. The base cast is 4d4 with an additional 2d4 per level above 2nd. 

The original line was adding 1 dice per spell level. This meant that casting CoD at level 5 was 7d10 rather than 10d10.