### PR TITLE
Updating jb2a file reference for cloud of daggers

### DIFF
--- a/scripts/animations/cloudOfDaggers.js
+++ b/scripts/animations/cloudOfDaggers.js
@@ -14,10 +14,12 @@ export function cloudOfDaggers({template, itemUuid}) {
         scaleDecision = 0.65;
     }
 
+    const animFileType = game.modules.get("jb2a_patreon")?.active ? "kunai" : "daggers";
+
     new Sequence()
         .effect()
             .attachTo(template, alignmentDecision)
-            .file(`jb2a.cloud_of_daggers.kunai.${animColor}`)
+            .file(`jb2a.cloud_of_daggers.${animFileType}.${animColor}`)
             .tieToDocuments(template)
             .scaleToObject(scaleDecision)
             .scaleIn(0, 500, {ease: "easeOutCubic"})


### PR DESCRIPTION
Added a default to cloud of daggers to use the free file path, then fall back to the paid file path if the user is a patron of jb2a.