### PR TITLE
Fix Stinking Cloud

### DIFF
--- a/packData/gps-spells-2024/Stinking_Cloud_cYrgFDHXoGG97NGX.json
+++ b/packData/gps-spells-2024/Stinking_Cloud_cYrgFDHXoGG97NGX.json
@@ -703,7 +703,7 @@
               "events": [
                 "tokenEnter"
               ],
-              "source": "let effectData = event.data.token.actor.appliedEffects.some(e => e.name === \"Stinking Cloud\");\n\nif(!effectData) {\neffectData = [{\n      \"disabled\": false,\n      \"name\": \"Stinking Cloud\",\n      \"img\": \"icons/commodities/materials/glass-orb-green.webp\",\n      \"transfer\": false\n}];\n\nawait MidiQOL.socket().executeAsGM(\"createEffects\", { actorUuid: event.data.token.actor.uuid, effects: effectData });\n}"
+              "source": "if(game.user.id !== game.gps.getPrimaryGM()) return;\nlet effectData = event.data.token.actor.appliedEffects.some(e => e.name === \"Stinking Cloud\");\n\nif(!effectData) {\neffectData = [{\n      \"disabled\": false,\n      \"name\": \"Stinking Cloud\",\n      \"img\": \"icons/commodities/materials/glass-orb-green.webp\",\n      \"transfer\": false,\n      \"flags.dae.showIcon\": true\n}];\n\nawait MidiQOL.socket().executeAsGM(\"createEffects\", { actorUuid: event.data.token.actor.uuid, effects: effectData });\n}"
             },
             "disabled": false,
             "flags": {},
@@ -725,7 +725,7 @@
               "events": [
                 "tokenExit"
               ],
-              "source": "let effectData = event.data.token.actor.appliedEffects.find(e => e.name === \"Stinking Cloud\");\n\nif(effectData) effectData.delete();"
+              "source": "if(game.user.id !== game.gps.getPrimaryGM()) return;\nlet effectData = event.data.token.actor.appliedEffects.find(e => e.name === \"Stinking Cloud\");\n\nif(effectData) effectData.delete();"
             },
             "disabled": false,
             "flags": {},

--- a/packData/gps-spells/Stinking_Cloud_LW4FED2CV3tFPnfe.json
+++ b/packData/gps-spells/Stinking_Cloud_LW4FED2CV3tFPnfe.json
@@ -637,7 +637,7 @@
               "events": [
                 "tokenEnter"
               ],
-              "source": "let effectData = event.data.token.actor.appliedEffects.some(e => e.name === \"Stinking Cloud\");\n\nif(!effectData) {\neffectData = [{\n      \"disabled\": false,\n      \"name\": \"Stinking Cloud\",\n      \"img\": \"icons/commodities/materials/glass-orb-green.webp\",\n      \"transfer\": false\n}];\n\nawait MidiQOL.socket().executeAsGM(\"createEffects\", { actorUuid: event.data.token.actor.uuid, effects: effectData });\n}"
+              "source": "if(game.user.id !== game.gps.getPrimaryGM()) return;\nlet effectData = event.data.token.actor.appliedEffects.some(e => e.name === \"Stinking Cloud\");\n\nif(!effectData) {\neffectData = [{\n      \"disabled\": false,\n      \"name\": \"Stinking Cloud\",\n      \"img\": \"icons/commodities/materials/glass-orb-green.webp\",\n      \"transfer\": false,\n      \"flags.dae.showIcon\": true\n}];\n\nawait MidiQOL.socket().executeAsGM(\"createEffects\", { actorUuid: event.data.token.actor.uuid, effects: effectData });\n}"
             },
             "disabled": false,
             "flags": {},
@@ -660,7 +660,7 @@
               "events": [
                 "tokenExit"
               ],
-              "source": "let effectData = event.data.token.actor.appliedEffects.find(e => e.name === \"Stinking Cloud\");\n\nif(effectData) effectData.delete();"
+              "source": "if(game.user.id !== game.gps.getPrimaryGM()) return;\nlet effectData = event.data.token.actor.appliedEffects.find(e => e.name === \"Stinking Cloud\");\n\nif(effectData) effectData.delete();"
             },
             "disabled": false,
             "flags": {},


### PR DESCRIPTION
I noticed that the token enter event would sometimes apply several effects. Token exit or concentration end would also throw permission errors on player clients and leave behind effects.

- Added early exit if not GM for every region behavior
- Added `flags.dae.showIcon: true` on effect